### PR TITLE
Support for empty `NamedTuple` in `flatten`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NestedTuples"
 uuid = "a734d2a7-8d68-409b-9419-626914d4061d"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.3.11"
+version = "0.3.12"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/leaves.jl
+++ b/src/leaves.jl
@@ -23,6 +23,7 @@ flatten(x, y...) = (flatten(x)..., flatten(y...)...)
 flatten(x::Tuple) = flatten(x...)
 flatten(x::NamedTuple) = flatten(values(x)...)
 flatten(x) = (x,)
+flatten() = ()
 
 
 using GeneralizedGenerated

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using NestedTuples: with, TypelevelExpr
     
     @test NestedTuples.flatten(x) == (:a, :b, :l, :u)
   
-    @test NestedTuples.flatten( (a = 1, b = (;), c = 2 ) == (1, 2)
+    @test NestedTuples.flatten( (a = 1, b = (;), c = 2) ) == (1, 2)
 
     @test NestedTuples.keysort(x) == (a = (a = :a, b = :b), q = (l = :l, u = :u))
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,8 @@ using NestedTuples: with, TypelevelExpr
     @test NestedTuples.exprify(x; rename=false) == ([:a, :b, :l, :u], :((a = (a = a, b = b), q = (l = l, u = u))))
     
     @test NestedTuples.flatten(x) == (:a, :b, :l, :u)
+  
+    @test NestedTuples.flatten( (a = 1, b = (;), c = 2 ) == (1, 2)
 
     @test NestedTuples.keysort(x) == (a = (a = :a, b = :b), q = (l = :l, u = :u))
     


### PR DESCRIPTION
Hi, I recently started using this package. (Mostly for `rmap` and `flatten`). 

I noticed that `flatten` fails when the data contains an empty `NamedTuple`. 
This PR adds a `flatten` fallback for empty `NamedTuples` returning an empty `Tuple`. 

A minimal example is 
```
flatten( (x = 1, y = (;), z = 2) )
```